### PR TITLE
⚡ Fix cache expiration logic unit mismatch

### DIFF
--- a/utils/social.ts
+++ b/utils/social.ts
@@ -75,7 +75,7 @@ export async function fetchSocialStats(): Promise<SocialStats> {
   const currentTime = Date.now();
 
   // Return cached data if it's still fresh
-  if (cachedStats && currentTime - lastFetchTime < CACHE_DURATION) {
+  if (cachedStats && currentTime - lastFetchTime < CACHE_DURATION * 1000) {
     return cachedStats;
   }
 


### PR DESCRIPTION
💡 **What:**
Updated `fetchSocialStats` in `utils/social.ts` to convert `CACHE_DURATION` (seconds) to milliseconds when comparing against `currentTime - lastFetchTime` (milliseconds).

🎯 **Why:**
The previous logic compared milliseconds to seconds (e.g., `4000ms < 3600s`), causing the cache to expire prematurely (effectively after 3.6 seconds instead of 1 hour). This led to unnecessary network requests to social APIs.

📊 **Measured Improvement:**
- **Baseline**: Cache expired after ~3.6 seconds.
- **Improved**: Cache now persists for the full 1 hour duration.
- Verified using a reproduction script that confirmed the cache holds after 4 seconds (which previously failed).
- This reduces API calls and potential rate limiting issues.

---
*PR created automatically by Jules for task [4431012401636246113](https://jules.google.com/task/4431012401636246113) started by @MrUnknownji*