### PR TITLE
⚡ Optimize Bot rendering pixel ratio

### DIFF
--- a/components/Bot/useBotScene.ts
+++ b/components/Bot/useBotScene.ts
@@ -59,7 +59,7 @@ export const useBotScene = ({
                 const width = container.clientWidth;
                 const height = container.clientHeight;
                 renderer.setSize(width, height);
-                renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+                renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
                 camera.aspect = width / height;
                 camera.updateProjectionMatrix();
             }


### PR DESCRIPTION
💡 **What:**
- Modified `components/Bot/useBotScene.ts` to cap the WebGL renderer's pixel ratio at 1.5 instead of 2.0 during resize events.

🎯 **Why:**
- High pixel density rendering (2x, 3x) is exponentially more expensive on the GPU.
- Visual difference between 1.5x and 2.0x on high-DPI screens is negligible for this art style, but the performance cost is significant.
- The initialization code already used 1.5x, so this fixes an inconsistency where resizing the window (e.g., rotating a mobile device) would accidentally degrade performance by jumping to 2.0x.

📊 **Measured Improvement:**
- **Baseline:** Max pixel ratio 2.0.
- **Improved:** Max pixel ratio 1.5.
- **Pixel Reduction:** On devices with DPR >= 2 (Retina Macs, most phones), this results in rendering **43.75% fewer pixels**.
- Verified via calculation script and manual code inspection.
- Build and Type checks passed.


---
*PR created automatically by Jules for task [2360191080844661022](https://jules.google.com/task/2360191080844661022) started by @MrUnknownji*